### PR TITLE
Ajustar perfis de execução, flyway e documentação

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,14 @@
+# Senha do usuário do banco de dados PostgreSQL
 HOTEL_RESERVATIONS_DB_PASSWORD=mude_a_senha_aqui
+
+# Profile ativo do Spring Boot
+# docker = Docker com seed
+# prod   = Docker sem seed
+SPRING_PROFILES_ACTIVE=docker
+
+# Origens permitidas para CORS (opcional)
+# Se não definir, o backend usa o valor padrão do application.yml
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
+
+# Versão da aplicação (opcional)
+APP_VERSION=dev

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/postgresql/postgresql-original.svg" width="90" alt="PostgreSQL Logo" />
 </p>
 
-<h1 align="center">Hotel Reservations Database</h1>
+<h1 align="center">Hotel Reservations</h1>
 
 <p align="center">
   Projeto acadêmico de banco de dados para sistema de reservas de quartos de hotel
@@ -86,12 +86,85 @@ Utilização de quadro Scrum para organização e acompanhamento das atividades 
 
 ## Instalação e Execução
 
-### Pré-requisitos
+### Configuração de ambiente (.env)
 
-- Java 21 ou superior
-- Docker
-- Docker Compose
-- Git
+Este projeto **não versiona arquivos `.env`**.  
+Você **deve criar um arquivo `.env` próprio na raiz do projeto** antes de executar a aplicação.
+
+Use o arquivo `.env.example` como base:
+
+```env
+# Senha do usuário do banco de dados PostgreSQL
+HOTEL_RESERVATIONS_DB_PASSWORD=mude_a_senha_aqui
+
+# Profile ativo do Spring Boot
+# docker = Docker com seed
+# prod   = Docker sem seed
+SPRING_PROFILES_ACTIVE=docker
+
+# Origens permitidas para CORS (opcional)
+# Se não definir, o backend usa o valor padrão do application.yml
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
+
+# Versão da aplicação (opcional)
+APP_VERSION=dev
+```
+
+Crie o seu **`.env`** copiando o exemplo:
+
+```bash
+cp .env.example .env
+```
+
+E ajuste os valores conforme necessário.
+
+---
+
+### Perfis de execução do projeto
+
+O projeto possui três formas principais de execução, controladas via **`SPRING_PROFILES_ACTIVE`** no **`.env`**
+
+#### Execução local (sem Docker, sem seed)
+
+- Profile não definido ou diferente de **`docker`** e **`prod`**
+- Banco PostgreSQL deve existir localmente
+- Não executa seeder
+- Flyway roda apenas migrations padrão 
+
+Configuração usada:
+- Database: **`hotel_reservations_dev`**
+- User: **`hotel_reservations_dev_app`**
+- Password: **`valor de HOTEL_RESERVATIONS_DB_PASSWORD`**
+
+Antes de rodar, é **obrigatório criar o usuário e o banco localmente.**
+
+Exemplo de execução do backend:
+
+```bash
+./mvnw spring-boot:run
+```
+
+#### Execução com Docker (com seed)
+
+- **`SPRING_PROFILES_ACTIVE=docker`**
+- Banco e backend sobem via Docker Compose
+- Seeder é executado automaticamente
+- Migrations padrão + migrations de desenvolvimento
+
+Esse profile é indicado para desenvolvimento inicial e testes rápidos.
+
+---
+
+#### Execução com Docker (sem seed)
+
+- **`SPRING_PROFILES_ACTIVE=prod`**
+- Banco e backend sobem via Docker Compose
+- Seeder não é executado
+- Apenas migrations oficiais
+
+Esse profile simula o comportamento de produção.
+
+---
 
 ### Subindo a aplicação com Docker Compose
 

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -2,11 +2,8 @@ spring:
   application:
     name: hotel-reservations-backend
 
-  profiles:
-    default: dev
-
   datasource:
-    url: jdbc:postgresql://localhost:5432/hotel_reservations_dev
+    url: jdbc:postgresql://localhost:5432/hotel_reservations_dev # rodar sem docker e sem seed
     username: hotel_reservations_dev_app
     password: ${HOTEL_RESERVATIONS_DB_PASSWORD:password}
     driver-class-name: org.postgresql.Driver
@@ -23,7 +20,7 @@ spring:
   jpa:
     open-in-view: false
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: false
@@ -33,8 +30,9 @@ spring:
 
   flyway:
     enabled: true
-    locations: classpath:db/migration
-    baseline-on-migrate: true
+    locations:
+      - classpath:db/migration
+    baseline-on-migrate: false
 
   lifecycle:
     timeout-per-shutdown-phase: 20s
@@ -91,17 +89,44 @@ springdoc:
     docExpansion: none
     filter: true
 
+app:
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:5173}
+
 ---
 spring:
   config:
     activate:
-      on-profile: docker
+      on-profile: docker # rodar o projeto no docker com seeder
+
+  flyway:
+    enabled: true
+    locations:
+      - classpath:db/migration
+      - classpath:db/migration-dev
+    baseline-on-migrate: false
 
   datasource:
     url: jdbc:postgresql://db:5432/hotel_reservations_dev
     username: hotel_reservations_dev_app
     password: ${HOTEL_RESERVATIONS_DB_PASSWORD}
 
-app:
-  cors:
-    allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:5173}
+---
+
+spring:
+  config:
+    activate:
+      on-profile: prod # rodar o projeto com docker sem seeder
+
+  flyway:
+    locations: classpath:db/migration
+    baseline-on-migrate: false
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+
+  datasource:
+    url: jdbc:postgresql://db:5432/hotel_reservations_dev
+    username: hotel_reservations_dev_app
+    password: ${HOTEL_RESERVATIONS_DB_PASSWORD}

--- a/backend/src/main/resources/db/migration-dev/R__seed.sql
+++ b/backend/src/main/resources/db/migration-dev/R__seed.sql
@@ -1,0 +1,5 @@
+-- teste
+
+-- Cliente
+INSERT INTO cliente (cpf, nome, data_nascimento, email, telefone)
+VALUES ('12345678901', 'João da Silva', '1995-06-15', 'joao@email.com', '11999999999');

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
       - public-net
       - internal-net
     environment:
-      SPRING_PROFILES_ACTIVE: docker
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE}
       HOTEL_RESERVATIONS_DB_PASSWORD: ${HOTEL_RESERVATIONS_DB_PASSWORD}
     depends_on:
       db:


### PR DESCRIPTION
- Alterado ddl-auto de create para validate no profile base
- Definido profile padrão para execução local sem Docker e sem seed
- Configurado profile docker para execução com Docker e seeder
- Configurado profile prod para execução com Docker sem seeder
- Criada pasta db/migration-dev para migrations DML
- Atualizado README com instruções claras de execução local, docker e perfis
- Ajusta o .env.example com variáveis e exemplos de uso